### PR TITLE
[ADD] support for CAA dns records

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,18 @@ dns RRs are stored in redis as json strings inside a hash map using address as f
 }
 ~~~
 
+#### CAA
+
+~~~json
+{
+    "caa":{
+        "flag" : 0,
+        "tag" : "issue",
+        "value" : "letsencrypt.org"
+    }
+}
+~~~
+
 #### example
 
 ~~~
@@ -186,6 +198,7 @@ $ORIGIN example.net.
  _ssh.tcp.host2.example.net.  300     SRV   <SRV RDATA>
  subdel.example.net.          300     NS    ns1.subdel.example.net.
  subdel.example.net.          300     NS    ns2.subdel.example.net.
+ host2.example.net                    CAA   0 issue "letsencrypt.org"
 ~~~
 
 above zone data should be stored at redis as follow:
@@ -206,5 +219,7 @@ redis-cli> hgetall example.net.
 12) "{\"ns\":[{\"ttl\":300, \"host\":\"ns1.subdel.example.net.\"},{\"ttl\":300, \"host\":\"ns2.subdel.example.net.\"}]}"
 13) "@"
 14) "{\"soa\":{\"ttl\":300, \"minttl\":100, \"mbox\":\"hostmaster.example.net.\",\"ns\":\"ns1.example.net.\",\"refresh\":44,\"retry\":55,\"expire\":66},\"ns\":[{\"ttl\":300, \"host\":\"ns1.example.net.\"},{\"ttl\":300, \"host\":\"ns2.example.net.\"}]}"
-redis-cli> 
+15) "host2"
+16)"{\"caa\":[{\"flag\":0, \"tag\":\"issue\", \"value\":\"letsencrypt.org\"}]}"
+redis-cli>
 ~~~

--- a/handler.go
+++ b/handler.go
@@ -65,6 +65,8 @@ func (redis *Redis) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.M
 		answers, extras = redis.SRV(qname, z, record)
 	case "SOA":
 		answers, extras = redis.SOA(qname, z, record)
+	case "CAA":
+		answers, extras = redis.CAA(qname, z, record)
 	default:
 		return redis.errorResponse(state, zone, dns.RcodeNotImplemented, nil)
 	}

--- a/redis.go
+++ b/redis.go
@@ -41,6 +41,7 @@ type Record struct {
 	NS    []NS_Record `json:"ns,omitempty"`
 	MX    []MX_Record `json:"mx,omitempty"`
 	SRV   []SRV_Record `json:"srv,omitempty"`
+	CAA   []CAA_Record `json:"caa,omitempty"`
 	SOA   SOA_Record `json:"soa,omitempty"`
 }
 
@@ -91,6 +92,12 @@ type SOA_Record struct {
 	Retry   uint32 `json:"retry"`
 	Expire  uint32 `json:"expire"`
 	MinTtl  uint32 `json:"minttl"`
+}
+
+type CAA_Record struct {
+	Flag  uint8 `json:"flag"`
+	Tag   string `json:"tag"`
+	Value string `json:"value"`
 }
 
 func (redis *Redis) LoadZones() {
@@ -248,6 +255,24 @@ func (redis *Redis) SOA(name string, z *Zone, record *Record) (answers, extras [
 	}
 	r.Serial = redis.serial()
 	answers = append(answers, r)
+	return
+}
+
+func (redis *Redis) CAA(name string, z *Zone, record *Record) (answers, extras []dns.RR) {
+	if record == nil {
+		return
+	}
+	for _, caa := range record.CAA {
+		if caa.Value == "" || caa.Tag == ""{
+			continue
+		}
+		r := new(dns.CAA)
+		r.Hdr = dns.RR_Header{Name: name, Rrtype: dns.TypeCAA, Class: dns.ClassINET}
+		r.Flag = caa.Flag
+		r.Tag = caa.Tag
+		r.Value = caa.Value
+		answers = append(answers, r)
+	}
 	return
 }
 


### PR DESCRIPTION
As CAA records should return either valid or empty response before issuing certificate, So we had some errors with letsencrypt for trying to get caa records. This commit will add support for handling these errors