### PR TITLE
Update module path.

### DIFF
--- a/setup.go
+++ b/setup.go
@@ -3,7 +3,7 @@ package redis
 import (
 	"strconv"
 
-	"github.com/mholt/caddy"
+	"github.com/caddyserver/caddy"
 	"github.com/coredns/coredns/core/dnsserver"
 	"github.com/coredns/coredns/plugin"
 )


### PR DESCRIPTION
The Caddy import path seems to have changed as per https://github.com/caddyserver/caddy/commit/f5720fecd663f521d832c1bca69e52ece43dc2b1

Building fails with the following error with the old module path.

```
go: github.com/mholt/caddy@v1.0.1: parsing go.mod: unexpected module path "github.com/caddyserver/caddy"
go: error loading module requirements
make: *** [Makefile:17: coredns] Error 1
``` 