### PR TITLE
the package address for caddyserver is outdated

### DIFF
--- a/setup.go
+++ b/setup.go
@@ -3,7 +3,7 @@ package redis
 import (
 	"strconv"
 
-	"github.com/mholt/caddy"
+	"github.com/caddyserver/caddy"
 	"github.com/coredns/coredns/core/dnsserver"
 	"github.com/coredns/coredns/plugin"
 )


### PR DESCRIPTION
Same problem as in many repositories, same fix. Just an update to right address on github.