### PR TITLE
Fallback to another server in case of no CNAME records found

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright TF TECH NV (Belgium)
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ echo 'redis:github.com/threefoldtech/coredns-redis' >> plugin.cfg
 make
 chmod +x coredns
 ```
+## development
+
+- clone repo git@github.com:threefoldtech/coredns-redis.git under ~/go/src/coredns-redis
+- in coredns repo in plugins dir add `redis:coredns-redis`
+- in coredns repo make
 
 ## syntax
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,16 @@
 *redis* enables reading zone data from redis database.
+
+## build
+
 this plugin should be located right next to *etcd* in *plugins.cfg*
+
+```sh
+git clone https://github.com/coredns/coredns
+cd coredns
+echo 'redis:github.com/threefoldtech/coredns-redis' >> plugin.cfg
+make
+chmod +x coredns
+```
 
 ## syntax
 

--- a/handler.go
+++ b/handler.go
@@ -121,6 +121,9 @@ func (redis *Redis) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.M
 		println(CNAMERecord.Host)
 		var query = strings.TrimSuffix(CNAMERecord.Host, "."+z.Name)
 		records := redis.get(query, z)
+		if records == nil {
+			continue
+		}
 
 		answersN := make([]dns.RR, 0, 10)
 		extrasN := make([]dns.RR, 0, 10)

--- a/lookup_test.go
+++ b/lookup_test.go
@@ -15,10 +15,10 @@ var zones = []string {
 	"example.com.", "example.net.",
 }
 
-var lookupEntries = [][][]string {
+var lookupEntries = [][][]string{
 	{
 		{"@",
-			"{\"soa\":{\"ttl\":300, \"minttl\":100, \"mbox\":\"hostmaster.example.com.\",\"ns\":\"ns1.example.com.\",\"refresh\":44,\"retry\":55,\"expire\":66}}",
+			"{\"a\":[{\"ttl\":300, \"ip\":\"5.5.5.5\"}], \"soa\":{\"ttl\":300, \"minttl\":100, \"mbox\":\"hostmaster.example.com.\",\"ns\":\"ns1.example.com.\",\"refresh\":44,\"retry\":55,\"expire\":66}}",
 		},
 		{"x",
 			"{\"a\":[{\"ttl\":300, \"ip\":\"1.2.3.4\"},{\"ttl\":300, \"ip\":\"5.6.7.8\"}]," +
@@ -28,7 +28,7 @@ var lookupEntries = [][][]string {
 			"\"mx\":[{\"ttl\":300, \"host\":\"mx1.example.com.\", \"preference\":10},{\"ttl\":300, \"host\":\"mx2.example.com.\", \"preference\":10}]}",
 		},
 		{"y",
-			"{\"cname\":[{\"ttl\":300, \"host\":\"x.example.com.\"}]}",
+			"{\"cname\":[{\"ttl\":300, \"host\":\"example.com.\"}]}",
 		},
 		{"ns1",
 			"{\"a\":[{\"ttl\":300, \"ip\":\"2.2.2.2\"}]}",

--- a/redis.go
+++ b/redis.go
@@ -3,9 +3,10 @@ package redis
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/miekg/dns"
 	"strings"
 	"time"
+
+	"github.com/miekg/dns"
 
 	"github.com/coredns/coredns/plugin"
 

--- a/redis.go
+++ b/redis.go
@@ -22,35 +22,7 @@ type Redis struct {
 	keyPrefix      string
 	keySuffix      string
 	Ttl            uint32
-	Zones          []string
 	LastZoneUpdate time.Time
-}
-
-func (redis *Redis) LoadZones() {
-	var (
-		reply interface{}
-		err error
-		zones []string
-	)
-
-	conn := redis.Pool.Get()
-	if conn == nil {
-		fmt.Println("error connecting to redis")
-		return
-	}
-	defer conn.Close()
-
-	reply, err = conn.Do("KEYS", redis.keyPrefix + "*" + redis.keySuffix)
-	if err != nil {
-		return
-	}
-	zones, err = redisCon.Strings(reply, nil)
-	for i, _ := range zones {
-		zones[i] = strings.TrimPrefix(zones[i], redis.keyPrefix)
-		zones[i] = strings.TrimSuffix(zones[i], redis.keySuffix)
-	}
-	redis.LastZoneUpdate = time.Now()
-	redis.Zones = zones
 }
 
 func (redis *Redis) A(name string, z *Zone, record *Record) (answers, extras []dns.RR) {
@@ -100,7 +72,7 @@ func (redis *Redis) TXT(name string, z *Zone, record *Record) (answers, extras [
 		if len(txt.Text) == 0 {
 			continue
 		}
-		r:= new(dns.TXT)
+		r := new(dns.TXT)
 		r.Hdr = dns.RR_Header{Name: dns.Fqdn(name), Rrtype: dns.TypeTXT,
 			Class: dns.ClassINET, Ttl: redis.minTtl(txt.Ttl)}
 		r.Txt = split255(txt.Text)
@@ -189,7 +161,7 @@ func (redis *Redis) CAA(name string, z *Zone, record *Record) (answers, extras [
 		return
 	}
 	for _, caa := range record.CAA {
-		if caa.Value == "" || caa.Tag == ""{
+		if caa.Value == "" || caa.Tag == "" {
 			continue
 		}
 		r := new(dns.CAA)
@@ -211,7 +183,7 @@ func (redis *Redis) AXFR(z *Zone) (records []dns.RR) {
 	// Allocate slices for rr Records
 	records = append(records, soa...)
 	for key := range z.Locations {
-		if key == "@"  {
+		if key == "@" {
 			location := redis.findLocation(z.Name, z)
 			record := redis.get(location, z)
 			soa, _ = redis.SOA(z.Name, z, record)
@@ -256,12 +228,12 @@ func (redis *Redis) AXFR(z *Zone) (records []dns.RR) {
 	records = append(records, soa...)
 
 	fmt.Println(records)
- 	return
+	return
 }
 
 func (redis *Redis) hosts(name string, z *Zone) []dns.RR {
 	var (
-		record *Record
+		record  *Record
 		answers []dns.RR
 	)
 	location := redis.findLocation(name, z)
@@ -295,12 +267,12 @@ func (redis *Redis) minTtl(ttl uint32) uint32 {
 	if redis.Ttl < ttl {
 		return redis.Ttl
 	}
-	return  ttl
+	return ttl
 }
 
 func (redis *Redis) findLocation(query string, z *Zone) string {
 	var (
-		ok bool
+		ok                                 bool
 		closestEncloser, sourceOfSynthesis string
 	)
 
@@ -309,7 +281,7 @@ func (redis *Redis) findLocation(query string, z *Zone) string {
 		return query
 	}
 
-	query = strings.TrimSuffix(query, "." + z.Name)
+	query = strings.TrimSuffix(query, "."+z.Name)
 
 	if _, ok = z.Locations[query]; ok {
 		return query
@@ -334,9 +306,9 @@ func (redis *Redis) findLocation(query string, z *Zone) string {
 
 func (redis *Redis) get(key string, z *Zone) *Record {
 	var (
-		err error
+		err   error
 		reply interface{}
-		val string
+		val   string
 	)
 	conn := redis.Pool.Get()
 	if conn == nil {
@@ -352,7 +324,7 @@ func (redis *Redis) get(key string, z *Zone) *Record {
 		label = key
 	}
 
-	reply, err = conn.Do("HGET", redis.keyPrefix + z.Name + redis.keySuffix, label)
+	reply, err = conn.Do("HGET", redis.keyPrefix+z.Name+redis.keySuffix, label)
 	if err != nil {
 		return nil
 	}
@@ -388,8 +360,8 @@ func splitQuery(query string) (string, string, bool) {
 		return "", "", false
 	}
 	var (
-		splits []string
-		closestEncloser string
+		splits            []string
+		closestEncloser   string
 		sourceOfSynthesis string
 	)
 	splits = strings.SplitAfterN(query, ".", 2)
@@ -405,7 +377,7 @@ func splitQuery(query string) (string, string, bool) {
 
 func (redis *Redis) Connect() {
 	redis.Pool = &redisCon.Pool{
-		Dial: func () (redisCon.Conn, error) {
+		Dial: func() (redisCon.Conn, error) {
 			opts := []redisCon.DialOption{}
 			if redis.redisPassword != "" {
 				opts = append(opts, redisCon.DialPassword(redis.redisPassword))
@@ -432,15 +404,35 @@ func (redis *Redis) save(zone string, subdomain string, value string) error {
 	}
 	defer conn.Close()
 
-	_, err = conn.Do("HSET", redis.keyPrefix + zone + redis.keySuffix, subdomain, value)
+	_, err = conn.Do("HSET", redis.keyPrefix+zone+redis.keySuffix, subdomain, value)
 	return err
+}
+
+func (redis *Redis) findZone(qname string) string {
+	conn := redis.Pool.Get()
+	if conn == nil {
+		fmt.Println("error connecting to redis")
+		return ""
+	}
+	defer conn.Close()
+	zone := ""
+	parts := strings.Split(qname, ".")
+	for i := 0; i < len(parts); i++ {
+		subdomain := strings.Join(parts[i:], ".")
+		key := redis.keyPrefix + subdomain + redis.keySuffix
+		ok, _ := redisCon.Bool(conn.Do("EXISTS", key))
+		if ok {
+			return subdomain
+		}
+	}
+	return zone
 }
 
 func (redis *Redis) load(zone string) *Zone {
 	var (
 		reply interface{}
-		err error
-		vals []string
+		err   error
+		vals  []string
 	)
 
 	conn := redis.Pool.Get()
@@ -450,7 +442,7 @@ func (redis *Redis) load(zone string) *Zone {
 	}
 	defer conn.Close()
 
-	reply, err = conn.Do("HKEYS", redis.keyPrefix + zone + redis.keySuffix)
+	reply, err = conn.Do("HKEYS", redis.keyPrefix+zone+redis.keySuffix)
 	if err != nil {
 		return nil
 	}
@@ -489,8 +481,7 @@ func split255(s string) []string {
 }
 
 const (
-	defaultTtl = 360
-	hostmaster = "hostmaster"
-	zoneUpdateTime = 10*time.Minute
+	defaultTtl     = 360
+	hostmaster     = "hostmaster"
 	transferLength = 1000
 )

--- a/setup.go
+++ b/setup.go
@@ -3,7 +3,7 @@ package redis
 import (
 	"strconv"
 
-	"github.com/caddyserver/caddy"
+	"github.com/coredns/caddy"
 	"github.com/coredns/coredns/core/dnsserver"
 	"github.com/coredns/coredns/plugin"
 )

--- a/setup.go
+++ b/setup.go
@@ -30,13 +30,13 @@ func setup(c *caddy.Controller) error {
 }
 
 func redisParse(c *caddy.Controller) (*Redis, error) {
-	redis := Redis {
-		keyPrefix:"",
-		keySuffix:"",
-		Ttl:300,
+	redis := Redis{
+		keyPrefix: "",
+		keySuffix: "",
+		Ttl:       300,
 	}
 	var (
-		err            error
+		err error
 	)
 
 	for c.Next() {
@@ -77,7 +77,7 @@ func redisParse(c *caddy.Controller) (*Redis, error) {
 					}
 					redis.readTimeout, err = strconv.Atoi(c.Val())
 					if err != nil {
-						redis.readTimeout = 0;
+						redis.readTimeout = 0
 					}
 				case "ttl":
 					if !c.NextArg() {
@@ -103,7 +103,6 @@ func redisParse(c *caddy.Controller) (*Redis, error) {
 		}
 
 		redis.Connect()
-		redis.LoadZones()
 
 		return &redis, nil
 	}


### PR DESCRIPTION
in case there're no cnames records found, we forward to the next plugin, happens in case of ca1.grid.tf where zerossl tries to validate against specific domains. So, we might be authoritative for the domain a.b.tf, but zerossl wants to create validationtext.a.b.tf cname to point to aaaa.bbb.c.como.g which we can't predict while registering the subdomain, so the solution is we allow forwarding to another nameserver that knows the needed CNAME records and create them during the zerossl communication 

```
. {
    log
    errors

    redis  {
        address 127.0.0.1:6379
    }

    forward . 174.138.6.79 8.8.8.8 1.1.1.1


}

```