### PR TITLE
Update setup.go

### DIFF
--- a/setup.go
+++ b/setup.go
@@ -3,7 +3,7 @@ package redis
 import (
 	"strconv"
 
-	"github.com/caddyserver/caddy"
+	"github.com/coredns/caddy"
 	"github.com/coredns/coredns/core/dnsserver"
 	"github.com/coredns/coredns/plugin"
 )


### PR DESCRIPTION
Fix import, as in the original form the plugin wouldn't build.

More details [here](https://github.com/threefoldtech/coredns-redis/issues/1)